### PR TITLE
Fixes PH tag, Workschedule Req & Display, OT date on details screen

### DIFF
--- a/app/DayType.php
+++ b/app/DayType.php
@@ -21,14 +21,20 @@ class DayType extends Model
   }
 
   public function getTimeRange(){
-    if($this->is_work_day == true){
-      $stime = new Carbon($this->start_time);
-      $etime = new Carbon($this->start_time);
-      $etime->addMinutes($this->total_minute);
-      return $stime->format('Hi') . '-' . $etime->format('Hi');
-    } else {
-      return $this->description;
-    }
+    // if($this->is_work_day == true){
+    //   $stime = new Carbon($this->start_time);
+    //   $etime = new Carbon($this->start_time);
+    //   $etime->addMinutes($this->total_minute);
+    //   return $stime->format('Hi') . '-' . $etime->format('Hi');
+    // } else {
+    //   //return $this->description;
+    //   return $stime->format('Hi') . '-' . $etime->format('Hi');
+    // }
+    
+    $stime = new Carbon($this->start_time);
+    $etime = new Carbon($this->start_time);
+    $etime->addMinutes($this->total_minute);
+    return $stime->format('Hi') . '-' . $etime->format('Hi');
   }
 
 

--- a/app/Http/Controllers/WorkSchedRuleController.php
+++ b/app/Http/Controllers/WorkSchedRuleController.php
@@ -286,12 +286,14 @@ class WorkSchedRuleController extends Controller
 
       if($sd){
         array_push($rv, [
+          'dtype' => $sd->Day->day_type,
           'type' => $sd->Day->code,
           'type_descr' => $sd->Day->description,
           'time' => $sd->Day->getTimeRange()
         ]);
       } else {
         array_push($rv, [
+          'dtype' => 'N/A',
           'type' => 'N/A',
           'type_descr' => 'N/A',
           'time' => ''

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -285,6 +285,12 @@ return [
               'can' => '5-user-mngmt',
           ],
           [
+              'text' => 'admin_shift_group_pattern',
+              'route' => 'admin.shiftGroupPattern',
+              'icon' => '',
+              'can' => '5-user-mngmt',
+          ],
+          [
               'text' => 'admin_shift_planning',
               'route' => 'admin.shiftplanning',
               'icon' => '',
@@ -505,16 +511,16 @@ return [
       [
           'header' => 'INFO',
       ],
+      [//Holiday calendar
+        'text' => 'guideline_calendar',
+        'url'  => 'guide/calendar',
+        'icon' => 'fa fa-calendar',
+        'guide' => '',
+      ],
       [//GUIDELINE
           'text' => 'user_guide',
           'icon' => 'fas fa-info-circle',
           'submenu' => [
-            [
-              'text' => 'guideline_calendar',
-              'url'  => 'guide/calendar',
-              'icon' => '',
-              'guide' => '',
-            ],
             [
               'text' => 'guideline_system',
               'url'  => 'guide/system',

--- a/resources/lang/vendor/adminlte/en/menu.php
+++ b/resources/lang/vendor/adminlte/en/menu.php
@@ -21,6 +21,7 @@ return [
     'paymentsch' => 'Payment Schedule',
     'payrollgroup' => 'Payroll Grouping',
     'admin_shift_group'   => 'Shift Groups',
+    'admin_shift_group_pattern'   => 'Shift Group Pattern',
     'admin_shift_planning'   => 'Shift Planning',
     'maintenance_order'   => 'Listing of Maintenance Order',
     'project_list'   => 'Listing of Project',
@@ -90,7 +91,7 @@ return [
     // 'user_guideline'  => 'User',
     // 'admin_guideline' => 'Admin',
 
-    'guideline_calendar' => 'Holiday Calendar',
+    'guideline_calendar' => 'HOLIDAY CALENDAR',
     'guideline_system' => 'System Guideline',
     'guideline_payment' => 'Payment Calendar',
     'week_remind' => 'Weekly Reminders'

--- a/resources/views/staff/otdetail.blade.php
+++ b/resources/views/staff/otdetail.blade.php
@@ -135,8 +135,8 @@
                                         @php(++$nox)
                                         <tr>
                                             <td>{{++$nod}}</td>
-                                            <td>{{ date('Hi', strtotime($details->start_time)) }}</td>
-                                            <td>@if(date('Hi', strtotime($details->end_time))=="0000") 2400 @else {{ date('Hi', strtotime($details->end_time))  }} @endif</td>
+                                            <td>{{ date('d.m.Y (H:i)', strtotime($details->start_time)) }}</td>
+                                            <td>@if(date('d.m.Y (H:i)', strtotime($details->end_time))=="0000") 2400 @else {{ date('d.m.Y (H:i)', strtotime($details->end_time))  }} @endif</td>
                                             <td>{{ $details->hour }}h {{$details->minute}}m</td>
                                             <td>
                                                 @if($details->clock_in!="")

--- a/resources/views/staff/workcalendar.blade.php
+++ b/resources/views/staff/workcalendar.blade.php
@@ -124,8 +124,13 @@
         </thead>
         <tbody>
           <tr>
+            
             @foreach($data as $h)
-            <td><b>{{ $h['type'] }}</b><br />{{ $h['time'] }}</td>
+            <td>
+              {{-- 20200930 disable due tu mismatch description & time --}}
+              {{-- <b>{{ $h['type'] }}</b><br /> --}}
+              <b>@if($h['dtype']=="N") Normal Day @elseif($h['dtype']=="O") Off Day @elseif($h['dtype']=="R") Rest Day @endif</b><br />
+              {{ $h['time'] }}</td>
             @endforeach
           </tr>
         </tbody>

--- a/resources/views/staff/workteamcalendar.blade.php
+++ b/resources/views/staff/workteamcalendar.blade.php
@@ -113,7 +113,7 @@
   </div>
   <div class="panel-body p-3">
     <div class="table-responsive">
-      <table id="tbltwsc" class="table table-bordered table-condensed cell-border" style="white-space: nowrap;">
+      <table id="tbltwsc" class="table table-bordered table-condensed table-striped table-hover cell-border" style="white-space: nowrap;">
         <thead>
           <tr>
             @foreach($header as $h)
@@ -127,7 +127,8 @@
             <td>{{ $s['staffno'] }}</td>
             <td style="text-align: left !important;">{{ $s['name'] }}</td>
             @foreach($s['data'] as $h)
-            <td ><b>{{ $h['type'] }}</b><br />{{ $h['time'] }}</td>
+            <td><b>@if($h['dtype']=="N") Normal Day @elseif($h['dtype']=="O") Off Day @elseif($h['dtype']=="R") Rest Day @endif</b><br />
+              {{ $h['time'] }}</td>
             @endforeach
           </tr>
           @endforeach


### PR DESCRIPTION
fix 1 & 4 - Hide edit button for workschedule request & remove description in work team schedule for shift employee
fix 2 & 3 - fix PH TG not working 30/7/2020 & calOT balance from working_hour 12hour
fix 5 - display OT date for approver/verifier in OT details screen 
[RE_ Post go live NEO-Fixes.pdf](https://github.com/otcstm/krono_lte2/files/5301474/RE_.Post.go.live.NEO-Fixes.pdf)
